### PR TITLE
fix for issue 291

### DIFF
--- a/lib/annotation-panel/annotation-panel.css
+++ b/lib/annotation-panel/annotation-panel.css
@@ -127,6 +127,11 @@ header.annotation-header {
   font-weight: bold;
 }
 
+.annotation-item-title:hover {
+text-decoration: none;
+cursor: none;
+}
+
 .annotation-item-text {
   padding: 0px;
   display: inline;

--- a/lib/annotation-panel/annotation-panel.css
+++ b/lib/annotation-panel/annotation-panel.css
@@ -66,6 +66,8 @@ header.annotation-header {
   margin: 0 0 0 auto;
   font-size: 14px;
   font-style:italic;
+  padding-left: 23.093px; /*hack to fix center alignment, adjusting for the width of the close icon*/
+
 }
 
 .annotation-items-container {

--- a/lib/annotation-panel/annotation-panel.css
+++ b/lib/annotation-panel/annotation-panel.css
@@ -127,11 +127,6 @@ header.annotation-header {
   font-weight: bold;
 }
 
-.annotation-item-title:hover {
-text-decoration: none;
-cursor: none;
-}
-
 .annotation-item-text {
   padding: 0px;
   display: inline;
@@ -144,7 +139,7 @@ a.annotation-item-text {
   color: blue;
 }
 
-.annotation-item-text:hover {
+a.annotation-item-text:hover {
   text-decoration: underline;
   cursor: pointer;
 }


### PR DESCRIPTION
Fixes the underline and hover behavior for annotation panel items which have no links (Illumina etc). And fixes center alignment of annotation description by adding padding equal to the width of the close icon. the more correct fix would be to make the description its own div, with display: block. 