### PR TITLE
Use regular lodash forOwn to trigger re-render of diagram

### DIFF
--- a/src/components/Diagram.tsx
+++ b/src/components/Diagram.tsx
@@ -8,7 +8,6 @@ import {
   defaultsDeep,
   defaultsAll,
   filter,
-  forOwn,
   isArray,
   isBoolean,
   isFinite,
@@ -22,6 +21,7 @@ import {
   toPairs,
   values
 } from "lodash/fp";
+import { forOwn } from "lodash";
 import { formatClassNames } from "../utils/formatClassNames";
 import {
   GetNamespacedId,
@@ -261,7 +261,7 @@ export class Diagram extends React.Component<any, any> {
 
     const nextProps = this.setFillOpacity(nextPropsRaw);
 
-    forOwn(function(prop, key) {
+    forOwn(nextProps, function(prop, key) {
       if (key === "filters") {
         that.setState({
           [key]: prop
@@ -274,7 +274,7 @@ export class Diagram extends React.Component<any, any> {
           [key]: prop
         });
       }
-    }, nextProps);
+    });
   }
 
   render() {


### PR DESCRIPTION
When changing any pathway entity in the entityMap, and passing the change on to the Kaavio component after the initial render of the component, the diagram is not updated. The cause seems to be in the forOwn function from lodash-fp, where the "key" argument was always undefined, so the state of Diagram wasn't updated for any changed property. Fixed it for now by switching to the regular lodash forOwn function.